### PR TITLE
Add key update to workaround outdated base image.

### DIFF
--- a/spaceros/Dockerfile
+++ b/spaceros/Dockerfile
@@ -21,6 +21,10 @@
 #   WORKSPACE   - The location for the Space ROS source code in the container (default: /root/src/spaceros_ws)
 
 FROM nvidia/cudagl:11.4.1-devel-ubuntu20.04
+# https://github.com/NVIDIA/cuda-repo-management/issues/1
+# Use new GPG keys for nvidia apt repositories that have not yet propagated to base images.
+RUN apt-key del 7fa2af80
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub
 
 ARG VCS_REF
 ARG VERSION="preview"


### PR DESCRIPTION
Key rotation in the nvidia repositories has not yet been propagated to
the baseimage used by this project. For now, update the key ourselves, we should be able to periodically check the base image for updates that may allow us to revert this
change. 

If we're "lucky" the build will fail when apt-key del has no key to remove.