### PR TITLE
edited demo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Space ROS Docker Image Templates
 
 See individual template directories for details.
 
+* [curiosity_demo] (./demo_spaceros)
 * [moveit2](./moveit2)
 * [moveit2_tutorials](./moveit2_tutorials)
 * [spaceros](./spaceros)

--- a/demo_spaceros/README.md
+++ b/demo_spaceros/README.md
@@ -2,9 +2,105 @@
 
 The Space ROS Demo Docker image uses the Space ROS docker image (*openrobotics/spaceros:latest*) as its base image. The Demo Dockerfile installs all of the prerequisite system dependencies to build Space ROS Demo
 
-## Demos
+## Building the Demo Docker
 
-See individual demo repositories for more details
+To build the docker image, run:
 
-* [Curiosity Rover](https://github.com/space-ros/demo)
+```
+$ ./build-image.sh
+```
+
+## Running the Demo Docker
+
+run the following to allow GUI passthrough:
+```
+$ xhost +local:docker
+```
+
+Then run:
+```
+$ ./run.sh
+```
+
+Depends on the host computer, you might need to remove ```--gpus all``` flag in ```run.sh```, which uses your GPUs
+
+## Running the Demo
+
+Launch the demo:
+```
+$ ros2 launch mars_rover mars_rover.launch.py
+```
+
+On the top left corner, click on the refresh button to show camera feed
+
+## Perform Tasks
+
+### Setup
+
+Open a new terminal and attach to the currently running container
+
+```
+$ docker -it exec <container-name> bash
+```
+
+Make sure packages are sourced
+
+```
+$ source /root/src/spaceros_ws/install/setup.bash
+```
+
+```
+$ source /root/src/spaceros_demo_ws/install/setup.bash
+```
+
+### Available Commands
+
+Drive the rover forward
+
+```
+$ ros2 service call /move_forward std_srvs/srv/Empty 
+```
+
+Stop the rover
+
+```
+$ ros2 service call /move_stop std_srvs/srv/Empty 
+```
+
+Turn left
+
+```
+$ ros2 service call /turn_left std_srvs/srv/Empty 
+```
+
+Turn right
+
+```
+$ ros2 service call /turn_right std_srvs/srv/Empty 
+```
+
+Open the tool arm:
+
+```
+$ ros2 service call /open_arm std_srvs/srv/Empty 
+```
+
+Close the tool arm:
+
+```
+$ ros2 service call /close_arm std_srvs/srv/Empty 
+```
+
+Open the mast (camera arm)
+
+```
+$ ros2 service call /mast_open std_srvs/srv/Empty 
+```
+
+Close the mast (camera arm)
+
+```
+$ ros2 service call /mast_close std_srvs/srv/Empty 
+```
+
 


### PR DESCRIPTION
Since the demo dockerfile does not explicitly refer back to the [demo repo](https://github.com/space-ros/demo), it would be more straightforward to put the instructions under the dockerfile README.

Added a link to the main README