### PR TITLE
Update the workspace names

### DIFF
--- a/demo_spaceros/Dockerfile
+++ b/demo_spaceros/Dockerfile
@@ -39,7 +39,7 @@ LABEL org.label-schema.vcs-ref=${VCS_REF}
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Define a few key variables
-ARG WORKSPACE=/root/src/spaceros_demo_ws
+ARG WORKSPACE=/root/src/spaceros_demo
 ARG ROSDISTRO=rolling
 ENV IGNITION_VERSION fortress
 WORKDIR ${WORKSPACE}
@@ -56,7 +56,7 @@ RUN rosinstall_generator \
   --rosdistro ${ROSDISTRO} \
   --deps \
   --upstream-development \
-  --exclude-path /root/src/spaceros_ws/src \
+  --exclude-path /root/src/spaceros/src \
   --exclude $(cat /tmp/excluded-pkgs.txt) -- \
   $(cat /tmp/spaceros-demo-pkgs.txt) \
   > /tmp/spaceros_demo_generated_pkgs.repos
@@ -70,7 +70,7 @@ RUN apt-get update -y
 RUN rosdep install --from-paths src --ignore-src -r -y
 
 # Build the demo
-RUN /bin/bash -c 'source /root/src/spaceros_ws/install/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release'
+RUN /bin/bash -c 'source /root/src/spaceros/install/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release'
 
 # Setup the entrypoint
 COPY ./entrypoint.sh /

--- a/demo_spaceros/README.md
+++ b/demo_spaceros/README.md
@@ -46,11 +46,11 @@ $ docker exec -it <container-name> bash
 Make sure packages are sourced
 
 ```
-$ source /root/src/spaceros_ws/install/setup.bash
+$ source /root/src/spaceros/install/setup.bash
 ```
 
 ```
-$ source /root/src/spaceros_demo_ws/install/setup.bash
+$ source /root/src/spaceros_demo/install/setup.bash
 ```
 
 ### Available Commands
@@ -58,49 +58,49 @@ $ source /root/src/spaceros_demo_ws/install/setup.bash
 Drive the rover forward
 
 ```
-$ ros2 service call /move_forward std_srvs/srv/Empty 
+$ ros2 service call /move_forward std_srvs/srv/Empty
 ```
 
 Stop the rover
 
 ```
-$ ros2 service call /move_stop std_srvs/srv/Empty 
+$ ros2 service call /move_stop std_srvs/srv/Empty
 ```
 
 Turn left
 
 ```
-$ ros2 service call /turn_left std_srvs/srv/Empty 
+$ ros2 service call /turn_left std_srvs/srv/Empty
 ```
 
 Turn right
 
 ```
-$ ros2 service call /turn_right std_srvs/srv/Empty 
+$ ros2 service call /turn_right std_srvs/srv/Empty
 ```
 
 Open the tool arm:
 
 ```
-$ ros2 service call /open_arm std_srvs/srv/Empty 
+$ ros2 service call /open_arm std_srvs/srv/Empty
 ```
 
 Close the tool arm:
 
 ```
-$ ros2 service call /close_arm std_srvs/srv/Empty 
+$ ros2 service call /close_arm std_srvs/srv/Empty
 ```
 
 Open the mast (camera arm)
 
 ```
-$ ros2 service call /mast_open std_srvs/srv/Empty 
+$ ros2 service call /mast_open std_srvs/srv/Empty
 ```
 
 Close the mast (camera arm)
 
 ```
-$ ros2 service call /mast_close std_srvs/srv/Empty 
+$ ros2 service call /mast_close std_srvs/srv/Empty
 ```
 
 

--- a/demo_spaceros/entrypoint.sh
+++ b/demo_spaceros/entrypoint.sh
@@ -2,5 +2,5 @@
 set -e
 
 # Setup the Demo environment
-source /root/src/spaceros_demo_ws/install/setup.bash
+source /root/src/spaceros_demo/install/setup.bash
 exec "$@"

--- a/moveit2/Dockerfile
+++ b/moveit2/Dockerfile
@@ -39,7 +39,7 @@ LABEL org.label-schema.vcs-ref=${VCS_REF}
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Define key locations
-ARG WORKSPACE=/root/src/moveit2_ws
+ARG WORKSPACE=/root/src/moveit2
 WORKDIR ${WORKSPACE}
 
 # Make sure the latest versions of packages are installed
@@ -86,10 +86,10 @@ RUN git clone https://github.com/ros-planning/moveit2.git -b main src/moveit2
 RUN vcs import src < moveit2.repos
 
 # Install system dependencies
-RUN /bin/bash -c 'source /root/src/spaceros_ws/install/setup.bash && rosdep install --from-paths ../spaceros_ws/src src --ignore-src --rosdistro rolling -y --skip-keys "console_bridge fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers rmw_connextdds ros_testing rmw_connextdds rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp composition demo_nodes_py lifecycle rosidl_typesupport_fastrtps_cpp rosidl_typesupport_fastrtps_c ikos diagnostic_aggregator diagnostic_updater joy"'
+RUN /bin/bash -c 'source /root/src/spaceros/install/setup.bash && rosdep install --from-paths ../spaceros/src src --ignore-src --rosdistro rolling -y --skip-keys "console_bridge fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers rmw_connextdds ros_testing rmw_connextdds rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp composition demo_nodes_py lifecycle rosidl_typesupport_fastrtps_cpp rosidl_typesupport_fastrtps_c ikos diagnostic_aggregator diagnostic_updater joy"'
 
 # Build MoveIt2
-RUN /bin/bash -c 'source /root/src/spaceros_ws/install/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON'
+RUN /bin/bash -c 'source /root/src/spaceros/install/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON'
 
 # Enable the container to run GUI apps and add a couple sample apps for testing
 RUN touch /root/.Xauthority

--- a/moveit2/README.md
+++ b/moveit2/README.md
@@ -40,5 +40,5 @@ $ ./run.sh
 Upon startup, the container automatically runs the moveit2_entrypoint.sh script, which sources the MoveIt2 and Space ROS environment files. You'll now be running inside the container and should see a prompt similar to this:
 
 ```
-root@8e73b41a4e16:/root/src/moveit2_ws# 
+root@8e73b41a4e16:/root/src/moveit2#
 ```

--- a/moveit2/entrypoint.sh
+++ b/moveit2/entrypoint.sh
@@ -2,5 +2,5 @@
 set -e
 
 # Setup the MoveIt2 environment
-source "/root/src/moveit2_ws/install/setup.bash"
+source "/root/src/moveit2/install/setup.bash"
 exec "$@"

--- a/moveit2_tutorials/Dockerfile
+++ b/moveit2_tutorials/Dockerfile
@@ -39,7 +39,7 @@ LABEL org.label-schema.vcs-ref=${VCS_REF}
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Define key locations
-ARG WORKSPACE=/root/src/moveit2_ws
+ARG WORKSPACE=/root/src/moveit2
 WORKDIR ${WORKSPACE}
 
 # Get the MoveIt2 Tutorials source code
@@ -52,7 +52,7 @@ RUN cd src/moveit2_tutorials && git checkout c98d7f10aefb8dffde60621ec5b72d1f5d1
 RUN vcs import src < moveit2_tutorials.repos
 
 # Build it
-RUN /bin/bash -c 'source /root/src/spaceros_ws/install/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release'
+RUN /bin/bash -c 'source /root/src/spaceros/install/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release'
 
 # Set up the entrypoint
 COPY ./entrypoint.sh /

--- a/moveit2_tutorials/README.md
+++ b/moveit2_tutorials/README.md
@@ -41,7 +41,7 @@ $ ./run.sh
 Upon startup, the container automatically runs the moveit2_entrypoint.sh script, which sources the MoveIt2 and Space ROS environment files. You'll now be running inside the container and should see a prompt similar to this:
 
 ```
-root@8e73b41a4e16:/root/src/moveit2_ws#
+root@8e73b41a4e16:/root/src/moveit2#
 ```
 
 Run the following command to launch the MoveIt2 tutorials demo launch file:

--- a/moveit2_tutorials/entrypoint.sh
+++ b/moveit2_tutorials/entrypoint.sh
@@ -2,5 +2,5 @@
 set -e
 
 # Setup the MoveIt2 environment
-source "/root/src/moveit2_ws/install/setup.bash"
+source "/root/src/moveit2/install/setup.bash"
 exec "$@"

--- a/spaceros/Dockerfile
+++ b/spaceros/Dockerfile
@@ -39,7 +39,7 @@ LABEL org.label-schema.vcs-ref=${VCS_REF}
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Define a few key variables
-ARG WORKSPACE=/root/src/spaceros_ws
+ARG WORKSPACE=/root/src/spaceros
 ARG REPOS_FILE_URL="https://raw.githubusercontent.com/space-ros/space-ros/main/ros2.repos"
 
 # https://github.com/NVIDIA/cuda-repo-management/issues/1

--- a/spaceros/README.md
+++ b/spaceros/README.md
@@ -1,6 +1,6 @@
 # Space ROS Docker Image
 
-The Dockerfile in this directory builds Space ROS from source code. 
+The Dockerfile in this directory builds Space ROS from source code.
 To include drivers for NVIDIA GPUs, the Space ROS docker image is based on the NVIDIA CudaGL development image, version 11.4.1, which is, in turn, based on Ubuntu 20.04.
 
 ## Building the Docker Image
@@ -41,13 +41,13 @@ $ ./run.sh
 Upon startup, the container automatically runs the ros_entrypoint.sh script, which sources the Space ROS environment file (setup.bash). You'll now be running inside the container and should see a prompt similar to this:
 
 ```
-root@d10d85c68f0e:/root/src/spaceros_ws#
+root@d10d85c68f0e:/root/src/spaceros#
 ```
 
 At this point, you can run the 'ros2' command line utility to make sure everything is working OK:
 
 ```
-root@d10d85c68f0e:/root/src/spaceros_ws# ros2
+root@d10d85c68f0e:/root/src/spaceros# ros2
 usage: ros2 [-h] [--use-python-default-buffering] Call `ros2 <command> -h` for more detailed usage. ...
 
 ros2 is an extensible command-line tool for ROS 2.
@@ -83,7 +83,7 @@ Commands:
 The Space ROS unit tests are not built as part of the Docker image build. To run the unit tests in the container, execute the following command from the top of the Space ROS workspace:
 
 ```
-root@d10d85c68f0e:/root/src/spaceros_ws# colcon test
+root@d10d85c68f0e:/root/src/spaceros# colcon test
 ```
 
 The tests include running the static analysis tools clang_tidy and cppcheck (which has the MISRA 2012 add-on enabled).
@@ -91,7 +91,7 @@ The tests include running the static analysis tools clang_tidy and cppcheck (whi
 You can use colcon's --packages-select option to run a subset of packages. For example, to run tests only for the rcpputils package and display the output directly to the console (as well as saving it to a log file), you can run:
 
 ```
-root@d10d85c68f0e:/root/src/spaceros_ws# colcon test --event-handlers console_direct+ --packages-select rcpputils
+root@d10d85c68f0e:/root/src/spaceros# colcon test --event-handlers console_direct+ --packages-select rcpputils
 ```
 
 ## Viewing Test Output
@@ -110,34 +110,34 @@ root@d10d85c68f0e:/root/src/spaceros_ws# colcon test --event-handlers console_di
   time="1.248"
 >
   <testcase
-    name="/root/src/spaceros_ws/src/rmw/rmw/src/allocators.c"
+    name="/root/src/spaceros/src/rmw/rmw/src/allocators.c"
     classname="rmw.clang_tidy"/>
   <testcase
-    name="/root/src/spaceros_ws/src/rmw/rmw/src/convert_rcutils_ret_to_rmw_ret.c"
+    name="/root/src/spaceros/src/rmw/rmw/src/convert_rcutils_ret_to_rmw_ret.c"
     classname="rmw.clang_tidy"/>
   <testcase
-    name="/root/src/spaceros_ws/src/rmw/rmw/src/event.c"
+    name="/root/src/spaceros/src/rmw/rmw/src/event.c"
     classname="rmw.clang_tidy"/>
   <testcase
-    name="/root/src/spaceros_ws/src/rmw/rmw/src/init.c"
+    name="/root/src/spaceros/src/rmw/rmw/src/init.c"
     classname="rmw.clang_tidy"/>
   <testcase
-    name="/root/src/spaceros_ws/src/rmw/rmw/src/init_options.c"
+    name="/root/src/spaceros/src/rmw/rmw/src/init_options.c"
     classname="rmw.clang_tidy"/>
   <testcase
-    name="/root/src/spaceros_ws/src/rmw/rmw/src/message_sequence.c"
+    name="/root/src/spaceros/src/rmw/rmw/src/message_sequence.c"
     classname="rmw.clang_tidy"/>
   <testcase
-    name="/root/src/spaceros_ws/src/rmw/rmw/src/names_and_types.c"
+    name="/root/src/spaceros/src/rmw/rmw/src/names_and_types.c"
     classname="rmw.clang_tidy"/>
   <testcase
-    name="/root/src/spaceros_ws/src/rmw/rmw/src/network_flow_endpoint.c"
+    name="/root/src/spaceros/src/rmw/rmw/src/network_flow_endpoint.c"
     classname="rmw.clang_tidy"/>
   <testcase
-    name="/root/src/spaceros_ws/src/rmw/rmw/src/network_flow_endpoint_array.c"
+    name="/root/src/spaceros/src/rmw/rmw/src/network_flow_endpoint_array.c"
     classname="rmw.clang_tidy"/>
   <testcase
-    name="/root/src/spaceros_ws/src/rmw/rmw/src/publisher_options.c"
+    name="/root/src/spaceros/src/rmw/rmw/src/publisher_options.c"
     classname="rmw.clang_tidy"/>
 
 <etc>
@@ -178,7 +178,7 @@ IKOS uses special compiler and linker settings in order to instrument and analyz
 To run an IKOS scan on all of the Space ROS test binaries (which will take a very long time), run the following command at the root of the Space ROS workspace:
 
 ```
-root@d10d85c68f0e:/root/src/spaceros_ws# CC="ikos-scan-cc" CXX="ikos-scan-c++" LD="ikos-scan-cc" colcon build --build-base build_ikos --install-base install_ikos --cmake-args -DSECURITY=ON -DINSTALL_EXAMPLES=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --no-warn-unused-cli
+root@d10d85c68f0e:/root/src/spaceros# CC="ikos-scan-cc" CXX="ikos-scan-c++" LD="ikos-scan-cc" colcon build --build-base build_ikos --install-base install_ikos --cmake-args -DSECURITY=ON -DINSTALL_EXAMPLES=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --no-warn-unused-cli
 ```
 
 The previous command generates the instrumented binaries and the associated output in a separate directory from the normal Space ROS build; the command uses *--build-base* option to specify **build_ikos** as the build output directory instead of the default **build** directory.
@@ -186,7 +186,7 @@ The previous command generates the instrumented binaries and the associated outp
 To run an IKOS scan on a specific package, such as rcpputils in this case, use the *--packages-select* option, as follows:
 
 ```
-root@d10d85c68f0e:/root/src/spaceros_ws# CC="ikos-scan-cc" CXX="ikos-scan-c++" LD="ikos-scan-cc" colcon build --build-base build_ikos --install-base install_ikos --packages-select rcpputils --cmake-args -DSECURITY=ON -DINSTALL_EXAMPLES=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --no-warn-unused-cli
+root@d10d85c68f0e:/root/src/spaceros# CC="ikos-scan-cc" CXX="ikos-scan-c++" LD="ikos-scan-cc" colcon build --build-base build_ikos --install-base install_ikos --packages-select rcpputils --cmake-args -DSECURITY=ON -DINSTALL_EXAMPLES=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --no-warn-unused-cli
 ```
 
 ## Generating IKOS Results
@@ -194,19 +194,19 @@ root@d10d85c68f0e:/root/src/spaceros_ws# CC="ikos-scan-cc" CXX="ikos-scan-c++" L
 To generate JUnit XML files for all of the binaries resulting from the build command in the previous step, you can use **colcon test**, as follows:
 
 ```
-root@d10d85c68f0e:/root/src/spaceros_ws# colcon test --build-base build_ikos --install-base install_ikos
+root@d10d85c68f0e:/root/src/spaceros# colcon test --build-base build_ikos --install-base install_ikos
 ```
 
 To generate a JUnit XML file for a specific package only, you can add the *--packages-select* option, as follows:
 
 ```
-root@d10d85c68f0e:/root/src/spaceros_ws# colcon test --build-base build_ikos --install-base install_ikos --packages-select rcpputils
+root@d10d85c68f0e:/root/src/spaceros# colcon test --build-base build_ikos --install-base install_ikos --packages-select rcpputils
 ```
 
 The 'colcon test' command runs various tests, including IKOS report generation, which reads the IKOS database generated in the previous analysis step and generates a JUnit XML report file. After running 'colcon test', you can view the JUnit XML files. For example, to view the JUnit XML file for IKOS scan of the rcpputils binaries you can use the following command:
 
 ```
-root@d10d85c68f0e:/root/src/spaceros_ws# more build_ikos/rcpputils/test_results/rcpputils/ikos.xunit.xml
+root@d10d85c68f0e:/root/src/spaceros# more build_ikos/rcpputils/test_results/rcpputils/ikos.xunit.xml
 
 ```
 

--- a/spaceros/entrypoint.sh
+++ b/spaceros/entrypoint.sh
@@ -2,5 +2,5 @@
 set -e
 
 # Setup the Space ROS environment
-source "/root/src/spaceros_ws/install/setup.bash"
+source "/root/src/spaceros/install/setup.bash"
 exec "$@"


### PR DESCRIPTION
Although the "_ws" is a convention for workspaces, I really don't see any benefit to using it since it's just a directory that contains ROS 2 packages. In fact, I'd rather see uniformity in the directory names under 'src' so that it doesn't matter if the directory contains ROS 2 packages or not. For example:

/home/spaceros-user/
    src/
        /ikos
        /spaceros
        /moveit2
        /moveit2_tutorials
        /curiosity_demo
       etc.

I could be convinced otherwise, but this seems cleaner to me. 

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>