### PR TITLE
Incorporate the RTEMS and Renode docker work into the docker repo

### DIFF
--- a/renode_rcc/Dockerfile
+++ b/renode_rcc/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:20.04
+WORKDIR /root
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update -y && \
+    apt-get install -y git \
+    xz-utils \
+    make \
+    vim \
+    ca-certificates \
+    wget \
+    automake \
+    autoconf \
+    netcat \
+    tree
+
+ARG RENODE_VERSION=1.13.0
+
+USER root
+RUN wget https://github.com/renode/renode/releases/download/v${RENODE_VERSION}/renode_${RENODE_VERSION}_amd64.deb && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends ./renode_${RENODE_VERSION}_amd64.deb python3-dev && \
+    rm ./renode_${RENODE_VERSION}_amd64.deb
+RUN pip3 install -r /opt/renode/tests/requirements.txt --no-cache-dir
+RUN git clone https://github.com/tonylitianyu/renode-rtems-leon3.git
+
+
+WORKDIR /root/renode-rtems-leon3
+RUN ./build-rtems.sh
+RUN ./build-prom.sh
+RUN mv rcc-1.3.0-gcc/ /opt/renode/
+RUN mv grlib-gpl-2021.2-b4267 /opt/renode/
+
+ENV PATH $PATH:/opt/renode/rcc-1.3.0-gcc/bin
+
+WORKDIR /root
+
+#renode
+#s @renode-rtems-leon3/leon3_rtems.resc

--- a/renode_rcc/README.md
+++ b/renode_rcc/README.md
@@ -1,0 +1,2 @@
+# renode-RCC
+Building [RTEMS Cross Compilation System (RCC)](https://www.gaisler.com/index.php/products/operating-systems/rtems), has a different directory structure compare to building RTEMS from source (might not be true). This will run RTEMS on leon3 in a renode simulation.

--- a/renode_rcc/build.sh
+++ b/renode_rcc/build.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env bash
+
+ORG=openrobotics
+IMAGE=renode
+TAG=latest
+
+VCS_REF=""
+VERSION=preview
+
+
+echo ""
+echo "##### Building Renode Docker Image #####"
+
+docker build -t $ORG/$IMAGE:$TAG \
+    --build-arg VCS_REF="$VCS_REF" \
+    --build-arg VERSION="$VERSION" .
+
+echo ""
+echo "##### Done! #####"
+

--- a/renode_rcc/run.sh
+++ b/renode_rcc/run.sh
@@ -1,0 +1,1 @@
+docker run -ti --rm -e DISPLAY -v $XAUTHORITY:/home/developer/.Xauthority --net=host openrobotics/renode

--- a/rtems/Dockerfile
+++ b/rtems/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:20.04
+WORKDIR /root
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update \
+    && apt-get install -y \
+        apt-utils build-essential \
+        vim u-boot-tools git cmake \
+        bison flex texinfo bzip2 \
+        xz-utils unzip python \
+        libexpat1-dev curl \
+        python-dev \
+        zlib1g-dev \
+        libtinfo-dev \
+        pax \
+        tree
+
+
+RUN mkdir -p development/rtems/5
+ENV PREFIX /root/development/rtems/5
+ENV RTEMS_VERSION 5
+
+RUN mkdir -p development/src
+WORKDIR /root/development/src
+
+RUN curl https://ftp.rtems.org/pub/rtems/releases/5/5.1/sources/rtems-source-builder-5.1.tar.xz | tar xJf -
+RUN mv rtems-source-builder-5.1/ rsb
+
+WORKDIR /root/development/src/rsb/rtems
+
+RUN ../source-builder/sb-set-builder --prefix=$PREFIX 5/rtems-sparc
+RUN ../source-builder/sb-set-builder --prefix=$PREFIX --target=sparc-rtems5 --with-rtems-bsp=leon3 --with-rtems-tests=yes 5/rtems-kernel
+
+WORKDIR /root
+
+RUN git clone https://github.com/robamu-org/rtems-cmake.git
+
+COPY example example/
+WORKDIR /root/example/build
+RUN cmake ../src/
+RUN cmake --build .
+
+WORKDIR /root
+
+RUN echo 'alias sparc-rtems5-gcc="development/rtems/5/bin/sparc-rtems5-gcc"' >> ~/.bashrc
+
+#sparc-rtems5-gcc -Wall -lc --entry main hello.c -o hello

--- a/rtems/README.md
+++ b/rtems/README.md
@@ -1,0 +1,4 @@
+# RTEMS
+This folder contains a Dockerfile that build RTEMS from source following the [official doc](https://docs.rtems.org/branches/master/user/overview/index.html).
+The target platform for the build is leon3.
+This will not run RTEMS, just perform the build and set up tools.

--- a/rtems/build.sh
+++ b/rtems/build.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env bash
+
+ORG=openrobotics
+IMAGE=rtems
+TAG=latest
+
+VCS_REF=""
+VERSION=preview
+
+
+echo ""
+echo "##### Building RTEMS Docker Image #####"
+
+docker build -t $ORG/$IMAGE:$TAG \
+    --build-arg VCS_REF="$VCS_REF" \
+    --build-arg VERSION="$VERSION" .
+
+echo ""
+echo "##### Done! #####"
+

--- a/rtems/example/src/CMakeLists.txt
+++ b/rtems/example/src/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.2)
+
+set(RTEMS_CONFIG_DIR
+	"/root/rtems-cmake"
+	 CACHE FILEPATH "Directory containing the RTEMS *.cmake files"
+)
+
+set(RTEMS_PREFIX
+	"/root/development/rtems/5"
+	CACHE FILEPATH "Prefix path for RTEMS"
+)
+
+set(RTEMS_BSP
+	"sparc/leon3"
+	CACHE FILEPATH "Board support package name"
+)
+
+include(${RTEMS_CONFIG_DIR}/RTEMSPreProjectConfig.cmake)
+rtems_pre_project_config(${RTEMS_PREFIX} ${RTEMS_BSP})
+
+set(CMAKE_TOOLCHAIN_FILE ${RTEMS_CONFIG_DIR}/RTEMSToolchain.cmake)
+
+project(Example)
+add_executable(Example main.cpp)

--- a/rtems/example/src/CMakeLists.txt
+++ b/rtems/example/src/CMakeLists.txt
@@ -22,3 +22,4 @@ set(CMAKE_TOOLCHAIN_FILE ${RTEMS_CONFIG_DIR}/RTEMSToolchain.cmake)
 
 project(Example)
 add_executable(Example main.cpp)
+

--- a/rtems/example/src/main.cpp
+++ b/rtems/example/src/main.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/rtems/example/src/main.cpp
+++ b/rtems/example/src/main.cpp
@@ -1,3 +1,4 @@
 int main() {
     return 0;
 }
+

--- a/rtems/run.sh
+++ b/rtems/run.sh
@@ -1,0 +1,1 @@
+docker run --rm --gpus all --net=host -e DISPLAY=$DISPLAY  --device=/dev/dri:/dev/dri --volume="$HOME/.Xauthority:/root/.Xauthority:rw" -it openrobotics/rtems


### PR DESCRIPTION
Instead of having a separate repository for the docker-based RTEMS-related work, bring it into the docker repo.

No changes yet to the contents, except the README, which was split across the two directories. Subsequent PRs will update these directories to ensure uniformity with other directories here. 

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>